### PR TITLE
fix: store remember-device cookie on passkey authentication

### DIFF
--- a/privacyIDEA-impl/src/main/java/org/privacyidea/action/PrivacyIDEAAuthenticator.java
+++ b/privacyIDEA-impl/src/main/java/org/privacyidea/action/PrivacyIDEAAuthenticator.java
@@ -111,6 +111,13 @@ public class PrivacyIDEAAuthenticator extends ChallengeResponseAction
                                                               headers);
                 if (piResponse != null)
                 {
+                    // Passkey success returns early below, bypassing the shared response handling at the
+                    // end of this method — so store/rotate/clear the remember-device cookie here too,
+                    // otherwise a passkey login with the box ticked would never persist the cookie.
+                    if (rememberMeManager != null)
+                    {
+                        rememberMeManager.relayResponse(piResponse);
+                    }
                     if (piResponse.authenticationSuccessful())
                     {
                         // Passkeys are usernameless: validateCheckPasskey resolves to whoever owns the


### PR DESCRIPTION
## Problem

A passkey login with **"remember this device"** ticked did not persist the cookie — the user was prompted for a second factor again on the next login.

The passkey branch in `PrivacyIDEAAuthenticator.doExecute` calls `finalizeAuthentication(...)` and returns early, bypassing the shared response handling further down that calls `RememberMeManager.relayResponse(piResponse)`. So the request correctly sent `request_persistent_cookie=1`, the server issued a `Set-Cookie`, the java-client captured it into `PIResponse.setCookieHeaders` — and the plugin then discarded it without ever setting the IdP-domain cookie.

Observed in `idp-process.log`:

- OTP login: `Extracting data from the response...` → `RememberMeManager: stored newly issued cookie (counter 1)` ✅
- Passkey login: straight to `Authentication successful, building success event...`, no `RememberMeManager` line at all ❌

## Fix

Relay the response as soon as `validateCheckPasskey()` returns, before the success/reject split — so a server-issued cookie *clear* on a rejected passkey is honoured as well.

## Other paths

- **Push** and **WebAuthn** assign `piResponse` and fall through to the shared handling — unaffected.
- `triggerSelectedToken` only fires a challenge (no auth result, no cookie).
- `validateCheckCompletePasskeyRegistration` / `cancelEnrollment` run after a `/validate/check` that already relayed, and neither sends `request_persistent_cookie`.

## Testing

Verified working against a live IdP + privacyIDEA 3.13.1.